### PR TITLE
Merge changes from Kiel branch to master

### DIFF
--- a/Macrolib/macro.ftn_hlrn_nc4
+++ b/Macrolib/macro.ftn_hlrn_nc4
@@ -1,0 +1,11 @@
+# module load cray-netcdf cray-hdf5 
+
+LIBS = -L/sw/dataformats/szip/2.1/smp1/intel/lib/ -lhdf5 -lhdf5_fortran -lnetcdf -lnetcdff -lhdf5_hl -lhdf5hl_fortran -lz
+NC4 = -D key_netcdf4
+
+F90=ftn -e F # force preprocessor irrespective of capitalization of file name
+             # extension
+FFLAGS= $(NC4) -O 2  $(NCDF) $(LIBS)
+LMPI=-lmpich
+
+INSTALL=$(HOME)/local/bin/

--- a/Macrolib/macro.gfortran_hlrn
+++ b/Macrolib/macro.gfortran_hlrn
@@ -1,0 +1,10 @@
+# module load gcc/4.9.1.hlrn netcdf/4.3.3.1 hdf5/1.8.14 
+
+INCS = $(NETCDF_INC) $(HDF5_INC)
+LIBS = $(NETCDF_F90_LIB) $(HDF5_F90_LIB)
+ 
+F90=gfortran
+
+FFLAGS= -O $(INCS) $(LIBS) -fno-second-underscore -ffree-line-length-256
+
+INSTALL=$(HOME)/local/bin

--- a/Macrolib/macro.gfortran_hlrn_nc4
+++ b/Macrolib/macro.gfortran_hlrn_nc4
@@ -1,0 +1,12 @@
+# module load gcc/4.9.1.hlrn netcdf/4.3.3.1 hdf5/1.8.14 
+
+INCS = $(NETCDF_INC) $(HDF5_INC)
+LIBS = $(NETCDF_F90_LIB) $(HDF5_F90_LIB)
+
+NC4 = -D key_netcdf4
+ 
+F90=gfortran
+
+FFLAGS= $(NC4) -O $(INCS) $(LIBS) -fno-second-underscore -ffree-line-length-256
+
+INSTALL=$(HOME)/local/bin

--- a/Macrolib/macro.ifort_nesh_fe
+++ b/Macrolib/macro.ifort_nesh_fe
@@ -1,0 +1,16 @@
+# Makefile for CDFTOOLS : nesh-fe.rz.uni-kiel.de
+#
+# $ module load intel netcdf_intel hfd5_intel
+#
+# (Linked dynamically!)
+
+INSTALL = $(HOME)/bin
+
+# libs
+LIBS = \
+  -L$(HDF5_DIR)/lib -L$(NETCDF_DIR)/lib -I$(NETCDF_DIR)/include \
+  -lhdf5 -lnetcdf -lnetcdff -lhdf5_hl \
+  -L/lib64 -limf -lm -lz 
+
+F90 = ifort
+FFLAGS = -O -assume byterecl -convert big_endian $(LIBS) 

--- a/cdf_xtrac_brokenline.f90
+++ b/cdf_xtrac_brokenline.f90
@@ -82,11 +82,11 @@ PROGRAM cdf_xtract_brokenline
    REAL(KIND=4), DIMENSION(:,:), ALLOCATABLE :: temper, saline      ! model Temperature and salinity
    REAL(KIND=4), DIMENSION(:,:), ALLOCATABLE :: uzonal, vmerid      ! model zonal and meridional velocity
    REAL(KIND=4), DIMENSION(:,:), ALLOCATABLE :: ssh, rmld           ! model SSH and MLD
-   REAL(KIND=4), DIMENSION(:,:), ALLOCATABLE :: icethick, icefra    ! ice thickness and fraction
+   REAL(KIND=4), DIMENSION(:,:), ALLOCATABLE :: ricethick, ricefra    ! ice thickness and fraction
    ! along section array (dimension x,z or x,1 )
    REAL(KIND=4), DIMENSION(:,:),   ALLOCATABLE :: tempersec, salinesec, uzonalsec, vmeridsec
    REAL(KIND=4), DIMENSION(:,:),   ALLOCATABLE :: sshsec, rmldsec
-   REAL(KIND=4), DIMENSION(:,:),   ALLOCATABLE :: icethicksec, icefrasec
+   REAL(KIND=4), DIMENSION(:,:),   ALLOCATABLE :: ricethicksec, ricefrasec
    REAL(KIND=4), DIMENSION(:,:),   ALLOCATABLE :: rlonsec, rlatsec, risec, rjsec
    REAL(KIND=4), DIMENSION(:,:),   ALLOCATABLE :: e3usec, e3vsec
    REAL(KIND=4), DIMENSION(:,:),   ALLOCATABLE :: batsec
@@ -290,7 +290,7 @@ PROGRAM cdf_xtract_brokenline
    ALLOCATE(hdepw(npiglo,npjglo), rmbat(npiglo, npjglo))
    IF ( lssh ) ALLOCATE (ssh (npiglo, npjglo))
    IF ( lmld ) ALLOCATE (rmld(npiglo, npjglo))
-   IF ( lice ) ALLOCATE(icethick(npiglo,npjglo),icefra(npiglo,npjglo))
+   IF ( lice ) ALLOCATE(ricethick(npiglo,npjglo),ricefra(npiglo,npjglo))
 
    ! allocate section working arrays
    ALLOCATE ( iilegs(nstamax-1, npiglo+npjglo, nsec), ijlegs(nstamax-1, npiglo+npjglo, nsec) )
@@ -372,7 +372,7 @@ PROGRAM cdf_xtract_brokenline
    ALLOCATE( uzonalsec(npsecmax-1,npk), vmeridsec(npsecmax-1,npk) )
    IF ( lssh ) ALLOCATE ( sshsec (npsecmax-1,1) )
    IF ( lmld ) ALLOCATE ( rmldsec(npsecmax-1,1) )
-   IF ( lice ) ALLOCATE(icethicksec(npsecmax-1,1),icefrasec(npsecmax-1,1))
+   IF ( lice ) ALLOCATE(ricethicksec(npsecmax-1,1),ricefrasec(npsecmax-1,1))
 
    ! Next arrays are initialized outside the vertical loop and thus require a section index
    ALLOCATE ( iisec    (npsecmax,nsec),     ijsec(npsecmax,nsec) ) 
@@ -487,8 +487,8 @@ PROGRAM cdf_xtract_brokenline
       dbarot(:) = 0.d0    ! reset barotropic transport  for all sections
       IF ( lssh ) ssh (:,:)     = getvar(cf_tfil  , cn_sossheig, 1, npiglo, npjglo, ktime = jt)
       IF ( lmld ) rmld(:,:)     = getvar(cf_tfil  , cn_somxl010, 1, npiglo, npjglo, ktime = jt)
-      IF ( lice ) icethick(:,:) = getvar(cf_icefil, cn_iicethic , 1, npiglo, npjglo, ktime = jt)
-      IF ( lice ) icefra(:,:)   = getvar(cf_icefil, cn_ileadfra , 1, npiglo, npjglo, ktime = jt)
+      IF ( lice ) ricethick(:,:) = getvar(cf_icefil, cn_iicethic , 1, npiglo, npjglo, ktime = jt)
+      IF ( lice ) ricefra(:,:)   = getvar(cf_icefil, cn_ileadfra , 1, npiglo, npjglo, ktime = jt)
 
       DO jk=1,npk   ! level loop , read only once the horizontal slab
          temper(:,:) = getvar(cf_tfil, cn_votemper, jk, npiglo, npjglo, ktime = jt)
@@ -519,15 +519,15 @@ PROGRAM cdf_xtract_brokenline
                         tempersec(jipt,jk) = 0. ; salinesec(jipt,jk) = 0.
                         IF ( ll_ssh ) sshsec(jipt,jk) = 0.
                         IF ( ll_mld ) rmldsec(jipt,jk) = 0.
-                        IF ( ll_ice ) icethicksec(jipt,jk) = 0.
-                        IF ( ll_ice ) icefrasec(jipt,jk) = 0.
+                        IF ( ll_ice ) ricethicksec(jipt,jk) = 0.
+                        IF ( ll_ice ) ricefrasec(jipt,jk) = 0.
                      ELSE
                         tempersec(jipt,jk) = 0.5 * ( temper(ii+1,ij) + temper(ii+1,ij+1) )
                         salinesec(jipt,jk) = 0.5 * ( saline(ii+1,ij) + saline(ii+1,ij+1) )
                         IF ( ll_ssh ) sshsec (jipt,jk) = 0.5 * ( ssh (ii+1,ij) + ssh (ii+1,ij+1) )
                         IF ( ll_mld ) rmldsec(jipt,jk) = 0.5 * ( rmld(ii+1,ij) + rmld(ii+1,ij+1) )
-                        IF ( ll_ice ) icethicksec(jipt,jk) = 0.5 * ( icethick(ii+1,ij) + icethick(ii+1,ij+1) )
-                        IF ( ll_ice ) icefrasec(jipt,jk)   = 0.5 * ( icefra(ii+1,ij) + icefra(ii+1,ij+1) )
+                        IF ( ll_ice ) ricethicksec(jipt,jk) = 0.5 * ( ricethick(ii+1,ij) + ricethick(ii+1,ij+1) )
+                        IF ( ll_ice ) ricefrasec(jipt,jk)   = 0.5 * ( ricefra(ii+1,ij) + ricefra(ii+1,ij+1) )
                      ENDIF
                      vmeridsec(jipt,jk) = vmerid(ii+1,ij) * normv_sec(jipt,jsec)
                      e3vsec   (jipt,jk) = e3v   (ii+1,ij)
@@ -538,15 +538,15 @@ PROGRAM cdf_xtract_brokenline
                         tempersec(jipt,jk) = 0. ; salinesec(jipt,jk) = 0.
                         IF ( ll_ssh ) sshsec (jipt,jk) = 0.
                         IF ( ll_mld ) rmldsec(jipt,jk) = 0.
-                        IF ( ll_ice ) icethicksec(jipt,jk) = 0.
-                        IF ( ll_ice ) icefrasec(jipt,jk) = 0.
+                        IF ( ll_ice ) ricethicksec(jipt,jk) = 0.
+                        IF ( ll_ice ) ricefrasec(jipt,jk) = 0.
                      ELSE
                         tempersec(jipt,jk) = 0.5 * ( temper(ii,ij) + temper(ii,ij+1) )
                         salinesec(jipt,jk) = 0.5 * ( saline(ii,ij) + saline(ii,ij+1) )
                         IF ( ll_ssh ) sshsec (jipt,jk) = 0.5 * ( ssh (ii,ij) + ssh (ii,ij+1) )
                         IF ( ll_mld ) rmldsec(jipt,jk) = 0.5 * ( rmld(ii,ij) + rmld(ii,ij+1) )
-                        IF ( ll_ice ) icethicksec(jipt,jk) = 0.5 * ( icethick(ii,ij) + icethick(ii,ij+1) )
-                        IF ( ll_ice ) icefrasec(jipt,jk) = 0.5 * ( icefra(ii,ij) + icefra(ii,ij+1) )
+                        IF ( ll_ice ) ricethicksec(jipt,jk) = 0.5 * ( ricethick(ii,ij) + ricethick(ii,ij+1) )
+                        IF ( ll_ice ) ricefrasec(jipt,jk) = 0.5 * ( ricefra(ii,ij) + ricefra(ii,ij+1) )
                      ENDIF
                      vmeridsec(jipt,jk) = vmerid(ii,ij) * normv_sec(jipt,jsec)
                      e3vsec   (jipt,jk) = e3v   (ii,ij)
@@ -561,15 +561,15 @@ PROGRAM cdf_xtract_brokenline
                         tempersec(jipt,jk) = 0. ; salinesec(jipt,jk) = 0.
                         IF ( ll_ssh ) sshsec (jipt,jk) = 0.
                         IF ( ll_mld ) rmldsec(jipt,jk) = 0.
-                        IF ( ll_ice ) icethicksec(jipt,jk) = 0.
-                        IF ( ll_ice ) icefrasec(jipt,jk) = 0.
+                        IF ( ll_ice ) ricethicksec(jipt,jk) = 0.
+                        IF ( ll_ice ) ricefrasec(jipt,jk) = 0.
                      ELSE
                         tempersec(jipt,jk) = 0.5 * ( temper(ii,ij) + temper(ii+1,ij) )
                         salinesec(jipt,jk) = 0.5 * ( saline(ii,ij) + saline(ii+1,ij) )
                         IF ( ll_ssh ) sshsec (jipt,jk) = 0.5 * ( ssh (ii,ij) + ssh (ii+1,ij) )
                         IF ( ll_mld ) rmldsec(jipt,jk) = 0.5 * ( rmld(ii,ij) + rmld(ii+1,ij) )
-                        IF ( ll_ice ) icethicksec(jipt,jk) = 0.5 * ( icethick(ii,ij) + icethick(ii+1,ij) )
-                        IF ( ll_ice ) icefrasec(jipt,jk) = 0.5 * ( icefra(ii,ij) + icefra(ii+1,ij) )
+                        IF ( ll_ice ) ricethicksec(jipt,jk) = 0.5 * ( ricethick(ii,ij) + ricethick(ii+1,ij) )
+                        IF ( ll_ice ) ricefrasec(jipt,jk) = 0.5 * ( ricefra(ii,ij) + ricefra(ii+1,ij) )
                      ENDIF
                      uzonalsec(jipt,jk) = uzonal(ii,ij) * normu_sec(jipt,jsec)
                      e3usec   (jipt,jk) = e3u   (ii,ij)
@@ -580,15 +580,15 @@ PROGRAM cdf_xtract_brokenline
                         tempersec(jipt,jk) = 0. ; salinesec(jipt,jk) = 0.
                         IF ( ll_ssh ) sshsec (jipt,jk) = 0.
                         IF ( ll_mld ) rmldsec(jipt,jk) = 0.
-                        IF ( ll_ice ) icethicksec(jipt,jk) = 0.
-                        IF ( ll_ice ) icefrasec(jipt,jk) = 0.
+                        IF ( ll_ice ) ricethicksec(jipt,jk) = 0.
+                        IF ( ll_ice ) ricefrasec(jipt,jk) = 0.
                      ELSE
                         tempersec(jipt,jk) = 0.5 * ( temper(ii,ij+1) + temper(ii+1,ij+1) )
                         salinesec(jipt,jk) = 0.5 * ( saline(ii,ij+1) + saline(ii+1,ij+1) )
                         IF ( ll_ssh ) sshsec (jipt,jk) = 0.5 * ( ssh (ii,ij+1) + ssh (ii+1,ij+1) )
                         IF ( ll_mld ) rmldsec(jipt,jk) = 0.5 * ( rmld(ii,ij+1) + rmld(ii+1,ij+1) )
-                        IF ( ll_ice ) icethicksec(jipt,jk) = 0.5 * ( icethick(ii,ij+1) + icethick(ii+1,ij+1) )
-                        IF ( ll_ice ) icefrasec(jipt,jk) = 0.5 * ( icefra(ii,ij+1) + icefra(ii+1,ij+1) )
+                        IF ( ll_ice ) ricethicksec(jipt,jk) = 0.5 * ( ricethick(ii,ij+1) + ricethick(ii+1,ij+1) )
+                        IF ( ll_ice ) ricefrasec(jipt,jk) = 0.5 * ( ricefra(ii,ij+1) + ricefra(ii+1,ij+1) )
                      ENDIF
                      uzonalsec(jipt,jk) = uzonal(ii,ij+1) * normu_sec(jipt,jsec)
                      e3usec   (jipt,jk) = e3u   (ii,ij+1)
@@ -619,8 +619,8 @@ PROGRAM cdf_xtract_brokenline
                  &                                                  jk, npsec(jsec)-1, 1, ktime=jt ) 
             IF (ll_ssh) ierr = putvar (ncout(jsec), id_varout(np_ssh), sshsec (:,jk), 1, npsec(jsec)-1, 1, ktime=jt )
             IF (ll_mld) ierr = putvar (ncout(jsec), id_varout(np_mld), rmldsec(:,jk), 1, npsec(jsec)-1, 1, ktime=jt )
-            IF (ll_ice) ierr = putvar (ncout(jsec), id_varout(np_icethick), icethicksec(:,jk), 1, npsec(jsec)-1, 1, ktime=jt )
-            IF (ll_ice) ierr = putvar (ncout(jsec), id_varout(np_icefra), icefrasec(:,jk), 1, npsec(jsec)-1, 1, ktime=jt )
+            IF (ll_ice) ierr = putvar (ncout(jsec), id_varout(np_icethick), ricethicksec(:,jk), 1, npsec(jsec)-1, 1, ktime=jt )
+            IF (ll_ice) ierr = putvar (ncout(jsec), id_varout(np_icefra), ricefrasec(:,jk), 1, npsec(jsec)-1, 1, ktime=jt )
 
             IF ( jt == 1 ) THEN   ! output of time independent variables at first time step only
                ! save a mask of the section

--- a/cdfio.F90
+++ b/cdfio.F90
@@ -1221,7 +1221,7 @@ CONTAINS
     REAL(KIND=4), DIMENSION(kpi,kpj) :: getvar            ! 2D REAL 4 holding variable field at klev
 
     INTEGER(KIND=4), DIMENSION(4)               :: istart, icount, inldim
-    INTEGER(KIND=4)                             :: incid, id_var, id_dimunlim, inbdim
+    INTEGER(KIND=4)                             :: incid, id_var, id_dimunlim, inbdim, inbdim2
     INTEGER(KIND=4)                             :: istatus, ilev, imin, jmin
     INTEGER(KIND=4)                             :: itime, ilog, ipiglo, imax
     INTEGER(KIND=4), SAVE                       :: ii, ij, ik0, ji, jj, ik1, ik
@@ -1286,12 +1286,13 @@ CONTAINS
       istatus=NF90_INQ_VARID( incid,'e3t_0', id_var)
       istatus=NF90_INQUIRE_VARIABLE( incid, id_var, xtype=ityp, ndims=inbdim) !, dimids, nAtts)
       IF ( istatus == NF90_NOERR ) THEN
+         PRINT *, 'e3t_0 has' , inbdim, 'dimensions'
         ! iom file , change names
         ! now try to detect if it is v2 or v3, in v3, e3t_ps exist and is a 2d variable
          istatus=NF90_INQ_VARID( incid,'e3t_ps', id_var)
+         istatus=NF90_INQUIRE_VARIABLE( incid, id_var, xtype=ityp, ndims=inbdim2) !, dimids, nAtts)
          !istatus2=NF90_INQUIRE_VAR( incid, id_var, 'e3t_0', xtype, ndims, dimids, nAtts)
-         PRINT *, 'e3t_0 has' , inbdim, 'dimensions'
-         IF ( istatus == NF90_NOERR ) THEN  
+         IF (( istatus == NF90_NOERR ) .and. (inbdim2 == 2)) THEN  
            ! case of NEMO_v3 zfr files
            ! look for mbathy and out it in memory, once for all
            IF ( .NOT. l_mbathy ) THEN

--- a/cdfpsi.f90
+++ b/cdfpsi.f90
@@ -138,8 +138,8 @@ PROGRAM cdfpsi
      CASE ('-mask') ; lmask = .TRUE.
      CASE ('-mean') ; lmean = .TRUE.  ; ll_v=.TRUE. ; ll_u=.TRUE.
      CASE ('-ssh' ) ; lssh  = .TRUE.  ; nvout=3
-     CASE ('-nc4' ) ; lnc4  = .TRUE. 
         CALL getarg( ijarg, cf_tfil ) ; ijarg=ijarg + 1 
+     CASE ('-nc4' ) ; lnc4  = .TRUE. 
      CASE ('-open') ; lopen = .TRUE.  ; ll_v=.TRUE. ; ll_u=.TRUE.
      CASE ('-o'   ) ; CALL getarg( ijarg, cf_out )   ; ijarg=ijarg + 1 
      CASE ('-ref') 

--- a/cdfpvor.f90
+++ b/cdfpvor.f90
@@ -24,7 +24,7 @@ PROGRAM cdfpvor
   !!        units : U, V in m.s-1
   !!           e1u, e2v, e1f, e2f in m
   !!           f, xsi in s-1
-  !!           Qpot, Qrel, Qstr in kg.m-4.s-1
+  !!           Qpot, Qrel, Qstr in 1.e-7 kg.m-4.s-1
   !!
   !! History : 2.1  : 12/2005  : A.M. Treguier : Original code
   !!           3.0  : 05/2011  : J.M. Molines  : Doctor norm + Lic., merge with cdfpv
@@ -112,14 +112,14 @@ PROGRAM cdfpvor
      PRINT *,'      '
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
-     PRINT *,'         variables : vorelvor (kg.m-4.s-1 ) relative vorticity'
-     PRINT *,'                     vostrvor (kg.m-4.s-1 ) stretching vorticity'
-     PRINT *,'                     vototvor (kg.m-4.s-1 ) total potential vorticity'
+     PRINT *,'         variables : vorelvor (1.e-7 kg.m-4.s-1 ) relative vorticity'
+     PRINT *,'                     vostrvor (1.e-7 kg.m-4.s-1 ) stretching vorticity'
+     PRINT *,'                     vototvor (1.e-7 kg.m-4.s-1 ) total potential vorticity'
      PRINT *,'                  Ertel PV are located at T points.'
      PRINT *,'           '
      PRINT *,'       With option -lspv :'
      PRINT *,'       netcdf file : lspv.nc'
-     PRINT *,'         variables :  volspv  (kg.m-4.s-1 ) large scale potential vorticity'
+     PRINT *,'         variables :  volspv  (1.e-7 kg.m-4.s-1 ) large scale potential vorticity'
      PRINT *,'                  LSPV is  located at W points.'
      PRINT *,'      '
      PRINT *,'     SEE ALSO :'
@@ -204,10 +204,10 @@ PROGRAM cdfpvor
   ! create output fileset
 
   ipk(:)= npk                   ! Those three variables are  3D
-  stypvar%cunits            = 'kg.m-4.s-1'
+  stypvar%cunits            = '1.e-7 kg.m-4.s-1'
   stypvar%rmissing_value    = 0.
-  stypvar%valid_min         = -1000.
-  stypvar%valid_max         = 1000.
+  stypvar%valid_min         = -10000.
+  stypvar%valid_max         = 10000.
   stypvar%conline_operation = 'N/A'
   stypvar%caxis             = 'TZYX'
 

--- a/cdfpvor.f90
+++ b/cdfpvor.f90
@@ -192,7 +192,10 @@ PROGRAM cdfpvor
   zpi         = ACOS(-1.)
   zomega      = 2.0  * zpi /(3600*24)
   d2fcor(:,:) = 2.d0 * zomega * SIN(gphit(:,:)*zpi/180.0)
-  dareat(:,:) = 4.d0 * e1t(:,:) * e2t(:,:)  ! factor of 4 to normalize relative vorticity
+
+  IF ( lertel ) THEN
+    dareat(:,:) = 4.d0 * e1t(:,:) * e2t(:,:)  ! factor of 4 to normalize relative vorticity
+  ENDIF
 
   gdepw(:) = getvare3(cn_fzgr, cn_gdepw, npk)
 

--- a/cdftransport.f90
+++ b/cdftransport.f90
@@ -594,7 +594,7 @@ PROGRAM cdftransport
       ierr     = createvar   (ncout,    stypvar,   nvarout,  ipk, id_varout, cdglobal=TRIM(cglobal) )
       ierr     = putheadervar(ncout,    cf_ufil,   ikx, iky, nclass, pnavlon=rdum, pnavlat=rdum, pdep=rclass )
       tim      = getvar1d    (cf_ufil,  cn_vtimec, npt     )
-      ierr     = putvar1d    (ncout,    tim,       npt, 'T')
+      ierr     = putvar1d    (ncout,    tim(itime:itime),       1, 'T')
 
       PRINT *, ' Give iimin, iimax, ijmin, ijmax '
       READ(*,*) iimin, iimax, ijmin, ijmax
@@ -830,24 +830,24 @@ PROGRAM cdftransport
          ! netcdf output 
          IF ( nclass > 1 ) THEN
             rdum(1,1) = REAL(dvoltrpsum(jclass)/1.e6)
-            ierr = putvar(ncout,id_varout(ivtrpcl), rdum, jclass, 1, 1, ktime=itime ) 
+            ierr = putvar(ncout,id_varout(ivtrpcl), rdum, jclass, 1, 1, 1 ) 
             IF ( lpm   ) THEN
                rdum(1,1) =  REAL(dvoltrpsump(jclass)/1.e6)
-               ierr = putvar(ncout,id_varout(iptrpcl), rdum, jclass, 1, 1, ktime=itime ) 
+               ierr = putvar(ncout,id_varout(iptrpcl), rdum, jclass, 1, 1, 1 ) 
                rdum(1,1) =  REAL(dvoltrpsumm(jclass)/1.e6)
-               ierr = putvar(ncout,id_varout(imtrpcl), rdum, jclass, 1, 1, ktime=itime ) 
+               ierr = putvar(ncout,id_varout(imtrpcl), rdum, jclass, 1, 1, 1 ) 
             ENDIF
             IF ( lheat ) THEN
                rdum(1,1) =  REAL(dheatrpsum(jclass)/1.e15)
-               ierr = putvar(ncout,id_varout(ihtrpcl), rdum, jclass, 1, 1, ktime=itime ) 
+               ierr = putvar(ncout,id_varout(ihtrpcl), rdum, jclass, 1, 1, 1 ) 
                rdum(1,1) =  REAL(dsaltrpsum(jclass)/1.e6)
-               ierr = putvar(ncout,id_varout(istrpcl), rdum, jclass, 1, 1, ktime=itime )
+               ierr = putvar(ncout,id_varout(istrpcl), rdum, jclass, 1, 1, 1 )
             ENDIF
          ENDIF
          rdum(1,1) = REAL(gdepw(ilev0(jclass)))
-         ierr = putvar(ncout,id_varout(itop), rdum, jclass, 1, 1, ktime=itime )
+         ierr = putvar(ncout,id_varout(itop), rdum, jclass, 1, 1, 1 )
          rdum(1,1) = REAL(gdepw(ilev1(jclass)+1))
-         ierr = putvar(ncout,id_varout(ibot), rdum, jclass, 1, 1, ktime=itime )
+         ierr = putvar(ncout,id_varout(ibot), rdum, jclass, 1, 1, 1 )
 
          dvoltrpbrtp = dvoltrpbrtp +  dvoltrpsum(jclass)
          IF ( lpm  ) THEN


### PR DESCRIPTION
## Macros

Commits e58d160, 7d9673f, 812f935 introduce Macros needed on machines used at Geomar, Kiel.

## Handle ice in ` cdf_xtrac_brokenline`

Commit b050ef0 adds handling of ice properties analogous to the recently added `ssh` and `mld`.

## Consistent time step in `cdftransport`

`cdftransport` allowed for selecting a time step to work on.  The resulting output contained the full time axis of the input data, but only had the transport for the selected time step, which was, however, associated with the first index of the time dimension. Commit 7eb7ca0 changes `cdftransport` to output only the selected time step with a consistent time axis that only covers the selected point in time.

## Units and valid ranges in `cdfpvor`

Commit 6c76ea0 changes the vorticity units to those actually returned by `cdfpvor`.  It also extends the range of valid data by a factor of 10.

## Unallocated variable in `cdfpvor`

Commit 5ceb41a handles a previously unallocated variable if `lertel` is set.

## Detection of the `mesh_zgr` version

Commit c463c63 changes the detection of the version of the mesh file to include the number of dimension of `e3t_ps`.

## Read T-File if `-ssh` is set in `cdfpsi`

Previously, the T-File was only read, if `-nc4` was given. Commit f86c4d4 changes this to the desired behaviour reading the T-File, if `-ssh` is set.