### PR TITLE
Added error control when trying to get dimension length in getvar

### DIFF
--- a/cdfio.F90
+++ b/cdfio.F90
@@ -1298,9 +1298,33 @@ CONTAINS
            IF ( .NOT. l_mbathy ) THEN
              PRINT *,'MESH_ZGR V3 detected'
              l_mbathy=.true.
-             istatus=NF90_INQ_DIMID(incid,'x',id_var) ; istatus=NF90_INQUIRE_DIMENSION(incid,id_var, len=ii )
-             istatus=NF90_INQ_DIMID(incid,'y',id_var) ; istatus=NF90_INQUIRE_DIMENSION(incid,id_var, len=ij )
-             istatus=NF90_INQ_DIMID(incid,'z',id_var) ; istatus=NF90_INQUIRE_DIMENSION(incid,id_var, len=ik0)
+
+             istatus=NF90_INQ_DIMID(incid,cn_x,id_var) ;
+             IF (istatus /= NF90_NOERR) THEN
+                istatus=NF90_INQ_DIMID(incid,'x',id_var) ;
+                IF ( istatus /=  NF90_NOERR ) THEN
+                   PRINT *, 'Problem reading x dimension : no x or ', cn_x, ' dimension found !' ; STOP
+                ENDIF
+             ENDIF
+             istatus=NF90_INQUIRE_DIMENSION(incid,id_var, len=ii )
+
+             istatus=NF90_INQ_DIMID(incid,cn_y,id_var) ;
+             IF (istatus /= NF90_NOERR) THEN
+                istatus=NF90_INQ_DIMID(incid,'y',id_var) ;
+                IF ( istatus /=  NF90_NOERR ) THEN
+                   PRINT *, 'Problem reading y dimension : no y or ', cn_y, ' dimension found !' ; STOP
+                ENDIF
+             ENDIF
+             istatus=NF90_INQUIRE_DIMENSION(incid,id_var, len=ij )
+
+             istatus=NF90_INQ_DIMID(incid,cn_z,id_var) ;
+             IF (istatus /= NF90_NOERR) THEN
+                istatus=NF90_INQ_DIMID(incid,'z',id_var) ;
+                IF ( istatus /=  NF90_NOERR ) THEN
+                   PRINT *, 'Problem reading y dimension : no z or ', cn_z, ' dimension found !' ; STOP
+                ENDIF
+             ENDIF
+             istatus=NF90_INQUIRE_DIMENSION(incid,id_var, len=ik0)
 
              ALLOCATE( mbathy(ii,ij))               ! mbathy is allocated on the whole domain
              ALLOCATE( e3t_ps(ii,ij),e3w_ps(ii,ij)) ! e3._ps  are  allocated on the whole domain


### PR DESCRIPTION
There was no error control when getting dimension length on getvar when getting e3t_0. I found it when trying to use a mesh file with i,j,lev dimensions instead of x,y,z. I have changed it to use cn_x, cn_y or cn_z and, if not found, try to use the default x,y,z. If those are also not found, the program will stop after giving an error message.



