### PR TITLE
ERR_HDL now stop programs with exit code != 0

### DIFF
--- a/src/cdfio.F90
+++ b/src/cdfio.F90
@@ -2787,7 +2787,7 @@ CONTAINS
     IF (kstatus /=  NF90_NOERR ) THEN
        PRINT *, 'ERROR in NETCDF routine, status=',kstatus
        PRINT *,NF90_STRERROR(kstatus)
-       STOP
+       STOP 1
     END IF
 
   END SUBROUTINE ERR_HDL


### PR DESCRIPTION
Changed ERR_HDL so when there is an error, CDFTOOLS will stop with an exit code != 0. This is the usual convention for all programs and will simplify failed executions detection.

Also trying to set a record for the smallest commit in the repository ;)