### PR TITLE
Added -ov and -ot to cdfmean

### DIFF
--- a/src/cdfmean.f90
+++ b/src/cdfmean.f90
@@ -116,8 +116,12 @@ PROGRAM cdfmean
      PRINT *,'       [ -var ]  : also compute the spatial variance of cdfvar '
      PRINT *,'       [ -zeromean ] : create a file with cdfvar having a zero spatial mean.'
      PRINT *,'       [ -o OUT-file] : specify the name of the output file instead of ',TRIM(cf_ncout)
-     PRINT *,'       [ -zo ZEROMEAN-file] : specify the name of the output file for option '
+     PRINT *,'       [ -ot OUTASCII-file] : specify the name of the output ASCII file instead '
+     PRINT *,'                   of ',TRIM(cf_out)
+     PRINT *,'       [ -oz ZEROMEAN-file] : specify the name of the output file for option '
      PRINT *,'                   -zeromean, instead of ', TRIM(cf_zerom)
+     PRINT *,'       [ -ov VAR-file] : specify the name of the output file for option '
+     PRINT *,'                   -var, instead of ', TRIM(cf_var)
      PRINT *,'      '
      PRINT *,'     REQUIRED FILES :'
      PRINT *,'       Files ', TRIM(cn_fhgr),', ', TRIM(cn_fzgr),', ', TRIM(cn_fmsk)
@@ -154,6 +158,10 @@ PROGRAM cdfmean
         CALL getarg(ijarg, cf_ncout ) ; ijarg = ijarg + 1
      CASE ('-oz' )
         CALL getarg(ijarg, cf_zerom ) ; ijarg = ijarg + 1
+     CASE ('-ov' )
+        CALL getarg(ijarg, cf_var ) ; ijarg = ijarg + 1
+     CASE ('-ot' )
+        CALL getarg(ijarg, cf_out ) ; ijarg = ijarg + 1
      CASE DEFAULT 
         ii=ii+1
         SELECT CASE (ii) 


### PR DESCRIPTION
Just to add full filename customization support to cdfmean. -ov option added following -oz convention. For cf_out I used -ot (from txt) but I am not really sure this is the best option.

I also corrected a typo.