### PR TITLE
getvare3 fix

### DIFF
--- a/src/cdfio.F90
+++ b/src/cdfio.F90
@@ -2168,7 +2168,7 @@ CONTAINS
     istatus=NF90_INQ_VARID ( incid,'gdept_0',id_var)
     IF ( istatus == NF90_NOERR) THEN
      icount(1)=kk ; icount(3)=1
-     SELECT CASE (clvar)
+     SELECT CASE (cdvar)
         CASE ('gdepw') 
            clvar='gdepw_0'
         CASE ('gdept')
@@ -2182,7 +2182,7 @@ CONTAINS
     istatus=NF90_INQ_VARID ( incid,'gdept_1d',id_var)
     IF ( istatus == NF90_NOERR) THEN
      icount(1)=kk ; icount(3)=1
-     SELECT CASE (clvar)
+     SELECT CASE (cdvar)
         CASE ('gdepw') 
            clvar='gdepw_1d'
         CASE ('gdept')


### PR DESCRIPTION
I was having trouble because my mesh file has both gdept_0 and gdept_1d.

Current version of getvare3  was going for the *_0 variable, but I only get the correct values when using the *_1d variable. With the proposed change, priority is reversed in  the case that both variables are present, so *_1d is used.

I don't know  if my use case is too specific, but nevertheless I submit the fix I had to make.