### PR TITLE
Added macro for conda compilation

### DIFF
--- a/Macrolib/macro.conda
+++ b/Macrolib/macro.conda
@@ -1,10 +1,6 @@
 # Makefile for CDFTOOLS
-#    $Rev: 522 $
-#    $Date: 2011-06-17 12:50:13 +0200 (Fri, 17 Jun 2011) $
 # --------------------------------------------------------------
 #
-#NETCDF_ROOT=/opt/netcdf-4.1.1-gfortran
-NETCDF_ROOT=/usr
 NCDF = -I$(CONDA_PREFIX)/include -L$(CONDA_PREFIX)/lib -lnetcdff -lnetcdf
 
 NC4= -D key_netcdf4

--- a/Macrolib/macro.conda
+++ b/Macrolib/macro.conda
@@ -1,0 +1,24 @@
+# Makefile for CDFTOOLS
+#    $Rev: 522 $
+#    $Date: 2011-06-17 12:50:13 +0200 (Fri, 17 Jun 2011) $
+# --------------------------------------------------------------
+#
+#NETCDF_ROOT=/opt/netcdf-4.1.1-gfortran
+NETCDF_ROOT=/usr
+NCDF = -I$(CONDA_PREFIX)/include -L$(CONDA_PREFIX)/lib -lnetcdff -lnetcdf
+
+NC4= -D key_netcdf4
+#CMIP6 = -D key_CMIP6
+CMIP6 =
+
+
+#F90=gfortran -v
+F90=gfortran 
+MPF90=
+#OMP=-fopenmp
+OMP=
+FFLAGS= -O  $(NCDF) $(NC4) $(CMIP6) -fPIC -Wl,-rpath-link,$(CONDA_PREFIX)/lib -fno-second-underscore -ffree-line-length-256 $(OMP)
+LMPI=-lmpich
+
+INSTALL=$(WORKDIR)/bin
+INSTALL_MAN=$(WORKDIR)/man


### PR DESCRIPTION
I have created a macro to compile CDFTOOLS using a conda environment (https://conda.io/docs/)

Even if conda is often not the best option for production, it is really easy to deploy and a great testing environment, as you can manage easily different GCC and  netCDF versions. 

If you are interested, I can also add a environment file that can be used to create a minimal environment with CDFTOOLS dependencies and a small document detailing how to compile CDFTOOLS using it
