### PR TITLE
added macros for ESM-tools 

### DIFF
--- a/Macrolib/macro.esmtools
+++ b/Macrolib/macro.esmtools
@@ -1,0 +1,23 @@
+# Makefile for CDFTOOLS
+#
+# Joakim Kjellsson, GEOMAR, March 2019
+#
+
+NCDF = -I/$(NEMO_NETCDF_DIR)/include/ -I/$(NEMO_HDF5_DIR)/include/
+LIBS = -L/$(NEMO_NETCDF_DIR)/lib/ -L/$(NEMO_HDF5_DIR)/lib/ -lnetcdff -lnetcdf 
+NC4 = -D key_netcdf4
+
+#CMIP6 = -D key_CMIP6
+CMIP6 =
+
+F90=$(FC)
+MPF90=
+#OMP=-mp=nonuma
+OMP=
+OPT=-O3
+FFLAGS= $(OPT) -fpp $(NCDF) $(LIBS) $(NC4) $(CMIP6) $(OMP)
+LMPI=-lmpich
+
+INSTALL=../../../bin/
+INSTALL_MAN=../../../man/
+

--- a/Macrolib/macro.ifort_hlrn4_nc4
+++ b/Macrolib/macro.ifort_hlrn4_nc4
@@ -1,0 +1,30 @@
+# Makefile for CDFTOOLS
+#    $Rev: 522 $
+#    $Date: 2011-06-17 12:50:13 +0200 (Fri, 17 Jun 2011) $
+# --------------------------------------------------------------
+#
+# Joakim Kjellsson, GEOMAR, March 2019
+#
+
+#NCDF = -I/usr/local/include -L/usr/local/lib -lnetcdf
+#NCDF = -l netcdf -l netcdff
+NCDF = -I/$(NETCDF_DIR)/include/ -I/$(HDF5_DIR)/include/
+LIBS = -L/$(NETCDF_DIR)/lib/ -L/$(HDF5_DIR)/lib/ -lnetcdf -lnetcdff
+#NC4 = -D 
+NC4 = -D key_netcdf4
+
+#CMIP6 = -D key_CMIP6
+CMIP6 =
+
+#F90=gfortran -v
+F90=ifort
+MPF90=
+#OMP=-mp=nonuma
+OMP=
+#FFLAGS= -O  $(NCDF) $(NC4) $(CMIP6)  -fno-second-underscore -ffree-line-length-256
+FFLAGS= -O3  -fpp $(NCDF) $(LIBS) $(NC4) $(CMIP6) $(OMP)
+LMPI=-lmpich
+
+INSTALL=../../../bin/
+INSTALL_MAN=../../../man/
+


### PR DESCRIPTION
Hi 

I'm using [(ESM-tools)](https://www.esm-tools.net) to run NEMO and a coupled OpenIFS + NEMO climate model, and I'd like to add a macro for CDF tools so that it can be compiled with the model. 
It's basically just adding a macro that uses the same paths for Netcdf, HDF5 and compilers as NEMO. 

I've also added a macro for HLRN-IV, which is the successor of HLRN-III for which there was already a macro. 

Cheers
Joakim 