### PR TITLE
Correct angle used with option vecrot

### DIFF
--- a/src/cdf_xtrac_brokenline.f90
+++ b/src/cdf_xtrac_brokenline.f90
@@ -711,7 +711,7 @@ PROGRAM cdf_xtract_brokenline
            END DO
 
            !Get alfa for the current section
-           angle= heading (dl_xmin,  dl_xmax,  dl_ymin, dl_ymax )
+           angled= heading (dl_xmin,  dl_xmax,  dl_ymin, dl_ymax )
            pi      = ACOS(-1.)
            angle = angled*pi/180.
            alfa  = angle - pi/2.


### PR DESCRIPTION
A typo in the angle computation led to a wrong alfa and consequently erroneous resulting normal and tangential velocities.