### PR TITLE
fix: change the salinity file path to get variable

### DIFF
--- a/src/cdfbuoyflx.f90
+++ b/src/cdfbuoyflx.f90
@@ -217,7 +217,7 @@ PROGRAM cdfbuoyflx
 
   DO jt = 1, npt
      ! read sss for masking purpose and sst
-     zsss(:,:) = getvar(cf_tfil, cv_sss, 1, npiglo, npjglo, ktime=jt)
+     zsss(:,:) = getvar(cf_sfil, cv_sss, 1, npiglo, npjglo, ktime=jt)
      zmask=1. ; WHERE ( zsss == zsps ) zmask=0.
      zsst(:,:) = getvar(cf_tfil, cv_sst, 1, npiglo, npjglo, ktime=jt)
 


### PR DESCRIPTION
Hello, 

This is a really simple fix in the buoyancy flux computation. The issue was when using the flag '-s', the code will crash saying that no variable could be found. The issue was that in the code, the salinity variable was searched in the temperature file, despite the `-s` option that allows to input a different file source.  The fix, is simply to use the other already defined variable in case the option `-s` is used. Within the code it is already included the case in which the flag `-s` is not use, to re-defined as to be the same file as the temperature:
https://github.com/meom-group/CDFTOOLS/blob/f3b5712134f259ef0e9bb11b10502f755a985821/src/cdfbuoyflx.f90#L179