### PR TITLE
adding check whether to use eosbn2_pol or eosbn2_80 to cdfbn2

### DIFF
--- a/src/cdfbn2.f90
+++ b/src/cdfbn2.f90
@@ -192,7 +192,11 @@ PROGRAM cdfbn2
         ELSE              ; e3w(:,:) = getvar(cn_fe3w, cn_ve3w , jk, npiglo, npjglo, ktime=it, ldiom=.NOT.lg_vvl )
         ENDIF
 
-        zwk(:,:,iup) = eosbn2(ztemp, zsal, gdep(jk), e3w, npiglo, npjglo ,iup, idown )* zmask(:,:)
+        IF ( ll_teos10 ) THEN
+           zwk(:,:,iup) = eosbn2(ztemp, zsal, gdep(jk), e3w, npiglo, npjglo ,iup, idown )* zmask(:,:)
+        ELSE
+           zwk(:,:,iup) = eosbn2(ztemp, zsal, gdep(jk), e3w, npiglo, npjglo ,iup, idown, .TRUE. )* zmask(:,:)
+        ENDIF
 
         IF ( .NOT. l_w ) THEN
            ! now put zn2 at T level (k )

--- a/src/cdfpvor.f90
+++ b/src/cdfpvor.f90
@@ -311,7 +311,11 @@ PROGRAM cdfpvor
 
            WHERE (e3w == 0 ) e3w = 1.
 
-           zwk(:,:,iup) = eosbn2 ( ztemp, zsal, gdepw(jk), e3w, npiglo, npjglo ,iup, idown)* tmask(:,:)
+           IF ( ll_teos10 ) THEN
+              zwk(:,:,iup) = eosbn2(ztemp, zsal, gdepw(jk), e3w, npiglo, npjglo ,iup, idown)* tmask(:,:)
+           ELSE
+              zwk(:,:,iup) = eosbn2(ztemp, zsal, gdepw(jk), e3w, npiglo, npjglo ,iup, idown, .TRUE. )* tmask(:,:)
+           ENDIF
            !
            IF ( lertel ) THEN ! put zn2 at T level (k )
               WHERE ( zwk(:,:,idown) == 0 ) 


### PR DESCRIPTION
Quick fix to allow `cdfbn2` to use `eosbn2_pol` to calculate N squared ONLY when `ll_teos10 == .TRUE.` and to use `eosbn2_80` otherwise.